### PR TITLE
fix smb block access

### DIFF
--- a/DRIVERS/Z001_SMB/z001_smb.c
+++ b/DRIVERS/Z001_SMB/z001_smb.c
@@ -285,6 +285,9 @@ static s32 z001_access(struct i2c_adapter *adap,
 		/* SMB address of the device */
 		MWRITE_D8(ioaddr, Z001_SMB_ADDR, ADDSHIFT(addr) | (read_write & 1));
 
+		/* The command is: read/write block */
+		MWRITE_D8(ioaddr, Z001_SMB_CMD, Z001_SMB_CMD_BLOCK_DATA);
+
 		/* Actual address we want to make the block transfer to & from */
 		MWRITE_D8(ioaddr, Z001_SMB_HSTCOM, command);
 


### PR DESCRIPTION
When reading or writing a block, the SMB command was not set to block mode. Without setting the mode, i2c communication becomes impossible after writing one block command.

Belongs to milestone: release 13MD05-90_02_01